### PR TITLE
Change default order of dbfs path elements to branch first.

### DIFF
--- a/invoke_databricks_wheel_tasks/utils/databricks.py
+++ b/invoke_databricks_wheel_tasks/utils/databricks.py
@@ -20,7 +20,7 @@ def default_dbfs_artifact_path(branch_name: Optional[str] = None) -> str:
     """Helper to construct a default artifact path to upload to in DBFS."""
     if branch_name is None:
         branch_name = git_current_branch()
-    return f"dbfs:/FileStore/wheels/{poetry_project_name()}/{branch_name}/"
+    return f"dbfs:/FileStore/wheels/{branch_name}/{poetry_project_name()}/"
 
 
 @lru_cache(maxsize=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "invoke-databricks-wheel-tasks"
-version = "0.6.3"
+version = "0.7.0"
 description = "Databricks Python Wheel dev tasks in a namespaced collection of tasks to enrich the Invoke CLI task runner."
 authors = ["Josh Peak <neozenith.dev@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Change default order of dbfs path elements to branch first. This keeps related wheels together and makes branch cleanup easier.